### PR TITLE
feat: toast notification component and use

### DIFF
--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { AuthProvider } from './contexts/AuthContext';
+import { ToastProvider } from './contexts/ToastContext';
 import { Route, Routes } from 'react-router-dom';
 import { Layout, PrivateRoute } from '@/components';
 import {
@@ -12,17 +13,22 @@ import {
 export default function App() {
   return (
     <AuthProvider>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<HomePage />} />
-          <Route path="signin" element={<SignInPage />} />
-          <Route element={<PrivateRoute />}>
-            <Route path="profile" element={<ProfilePage />} />
-            <Route path="profile-settings" element={<ProfileSettingsPage />} />
+      <ToastProvider>
+        <Routes>
+          <Route path="/" element={<Layout />}>
+            <Route index element={<HomePage />} />
+            <Route path="signin" element={<SignInPage />} />
+            <Route element={<PrivateRoute />}>
+              <Route path="profile" element={<ProfilePage />} />
+              <Route
+                path="profile-settings"
+                element={<ProfileSettingsPage />}
+              />
+            </Route>
+            <Route path="*" element={<NotFoundPage />} />
           </Route>
-          <Route path="*" element={<NotFoundPage />} />
-        </Route>
-      </Routes>
+        </Routes>
+      </ToastProvider>
     </AuthProvider>
   );
 }

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -1,5 +1,5 @@
-import { AuthProvider } from './contexts/AuthContext';
-import { ToastProvider } from './contexts/ToastContext';
+import { AuthProvider } from '@/contexts/AuthContext';
+import { ToastProvider } from '@/contexts/ToastContext';
 import { Route, Routes } from 'react-router-dom';
 import { Layout, PrivateRoute } from '@/components';
 import {

--- a/src/frontend/src/components/Layout.jsx
+++ b/src/frontend/src/components/Layout.jsx
@@ -1,4 +1,4 @@
-import NavBar from '@/components/NavBar/NavBar';
+import { NavBar } from '@/components';
 import { Outlet } from 'react-router-dom';
 
 export default function Layout() {

--- a/src/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/src/frontend/src/components/LoginForm/LoginForm.jsx
@@ -26,6 +26,7 @@ export default function LoginForm({ onLoginResult }) {
         <Form.Label>Username</Form.Label>
         <Form.Control
           type="text"
+          autoComplete={credentials.username}
           placeholder="Enter username"
           value={credentials.username}
           onChange={(e) =>
@@ -37,6 +38,7 @@ export default function LoginForm({ onLoginResult }) {
         <Form.Label>Password</Form.Label>
         <Form.Control
           type="password"
+          autoComplete={credentials.password}
           placeholder="Password"
           value={credentials.password}
           onChange={(e) =>

--- a/src/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/src/frontend/src/components/LoginForm/LoginForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useAuth } from '@/hooks/useAuth';
+import { useAuth } from '@/hooks';
 import { Button, Form } from 'react-bootstrap';
 import './LoginForm.css';
 

--- a/src/frontend/src/components/NavBar/Navbar.jsx
+++ b/src/frontend/src/components/NavBar/Navbar.jsx
@@ -1,25 +1,22 @@
-import { Container, Nav, Navbar, NavDropdown, Toast } from 'react-bootstrap/';
+import { Container, Nav, Navbar, NavDropdown } from 'react-bootstrap/';
 import { Link } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
+import { useToast } from '@/hooks/useToast';
 import { useEffect, useState } from 'react';
 import SearchForm from '@/components/SearchForm/SearchForm';
 import LoginForm from '@/components/LoginForm/LoginForm';
+import ToastNotification from '@/components/ToastNotification/ToastNotification';
 import 'bootstrap-icons/font/bootstrap-icons.css';
 import './NavBar.css';
 
 export default function NavBar({ username }) {
   const { user } = useAuth();
   const [showLogin, setShowLogin] = useState(false);
-  const [showToast, setShowToast] = useState(false);
-  const [toastMessage, setToastMessage] = useState('');
-  const [toastVariant, setToastVariant] = useState('');
+  const { showToastMessage } = useToast();
 
   const handleLoginResult = (success, message) => {
-    setToastMessage(message);
-    setToastVariant(success ? 'success' : 'danger');
-    setShowToast(true);
+    showToastMessage(message, success ? 'success' : 'danger');
   };
-
   const handleToggle = () => {
     setShowLogin(!showLogin);
   };
@@ -82,16 +79,7 @@ export default function NavBar({ username }) {
           </Navbar.Collapse>
         </Container>
       </Navbar>
-      <Toast
-        onClose={() => setShowToast(false)}
-        show={showToast}
-        delay={3000}
-        autohide
-        bg={toastVariant}
-        className="position-fixed bottom-0 end-0 m-3"
-      >
-        <Toast.Body className="text-white">{toastMessage}</Toast.Body>
-      </Toast>
+      <ToastNotification />
     </>
   );
 }

--- a/src/frontend/src/components/NavBar/Navbar.jsx
+++ b/src/frontend/src/components/NavBar/Navbar.jsx
@@ -1,11 +1,8 @@
 import { Container, Nav, Navbar, NavDropdown } from 'react-bootstrap/';
 import { Link } from 'react-router-dom';
-import { useAuth } from '@/hooks/useAuth';
-import { useToast } from '@/hooks/useToast';
+import { useAuth, useToast } from '@/hooks';
 import { useEffect, useState } from 'react';
-import SearchForm from '@/components/SearchForm/SearchForm';
-import LoginForm from '@/components/LoginForm/LoginForm';
-import ToastNotification from '@/components/ToastNotification/ToastNotification';
+import { SearchForm, LoginForm, ToastNotification } from '@/components';
 import 'bootstrap-icons/font/bootstrap-icons.css';
 import './NavBar.css';
 

--- a/src/frontend/src/components/PrivateRoute.jsx
+++ b/src/frontend/src/components/PrivateRoute.jsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
-import { useAuth } from '@/hooks/useAuth';
-import { useToast } from '@/hooks/useToast';
+import { useAuth, useToast } from '@/hooks';
 
 export default function PrivateRoute() {
   const { user } = useAuth();

--- a/src/frontend/src/components/PrivateRoute.jsx
+++ b/src/frontend/src/components/PrivateRoute.jsx
@@ -1,8 +1,21 @@
+import { useEffect } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
+import { useToast } from '@/hooks/useToast';
 
 export default function PrivateRoute() {
   const { user } = useAuth();
+  const { showToastMessage } = useToast();
 
-  return user ? <Outlet /> : <Navigate to="/" />;
+  useEffect(() => {
+    if (!user) {
+      showToastMessage('You are not logged in.', 'danger');
+    }
+  }, [user, showToastMessage]);
+
+  if (!user) {
+    return <Navigate to="/" />;
+  }
+
+  return <Outlet />;
 }

--- a/src/frontend/src/components/ToastNotification/ToastNotification.jsx
+++ b/src/frontend/src/components/ToastNotification/ToastNotification.jsx
@@ -1,5 +1,5 @@
 import { Toast } from 'react-bootstrap';
-import { useToast } from '@/hooks/useToast';
+import { useToast } from '@/hooks';
 
 export default function ToastNotification() {
   const { toastMessage, toastVariant, showToast, showToastMessage } =

--- a/src/frontend/src/components/ToastNotification/ToastNotification.jsx
+++ b/src/frontend/src/components/ToastNotification/ToastNotification.jsx
@@ -1,0 +1,20 @@
+import { Toast } from 'react-bootstrap';
+import { useToast } from '@/hooks/useToast';
+
+export default function ToastNotification() {
+  const { toastMessage, toastVariant, showToast, showToastMessage } =
+    useToast();
+
+  return (
+    <Toast
+      onClose={() => showToastMessage(null)}
+      show={showToast}
+      delay={3000}
+      autohide
+      bg={toastVariant}
+      className="position-fixed bottom-0 end-0 m-3"
+    >
+      <Toast.Body className="text-white">{toastMessage}</Toast.Body>
+    </Toast>
+  );
+}

--- a/src/frontend/src/components/UpdateProfileForm/UpdateProfileForm.jsx
+++ b/src/frontend/src/components/UpdateProfileForm/UpdateProfileForm.jsx
@@ -28,6 +28,7 @@ export default function UpdateProfileForm({ onSubmit, initialData }) {
         <Form.Label>Username</Form.Label>
         <Form.Control
           type="text"
+          autoComplete={username}
           value={username}
           onChange={(e) => setUsername(e.target.value)}
         />
@@ -36,6 +37,7 @@ export default function UpdateProfileForm({ onSubmit, initialData }) {
         <Form.Label>Email</Form.Label>
         <Form.Control
           type="email"
+          autoComplete={email}
           value={email}
           onChange={(e) => setEmail(e.target.value)}
         />
@@ -44,6 +46,7 @@ export default function UpdateProfileForm({ onSubmit, initialData }) {
         <Form.Label>Password</Form.Label>
         <Form.Control
           type="password"
+          autoComplete={password}
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />

--- a/src/frontend/src/components/index.js
+++ b/src/frontend/src/components/index.js
@@ -5,3 +5,4 @@ export { default as SearchForm } from './SearchForm/SearchForm';
 export { default as UpdateProfileForm } from './UpdateProfileForm/UpdateProfileForm';
 export { default as Layout } from './Layout';
 export { default as PrivateRoute } from './PrivateRoute';
+export { default as ToastNotification } from './ToastNotification/ToastNotification';

--- a/src/frontend/src/contexts/ToastContext.jsx
+++ b/src/frontend/src/contexts/ToastContext.jsx
@@ -1,0 +1,28 @@
+import { createContext, useState, useContext } from 'react';
+
+const ToastContext = createContext();
+
+export const useToast = () => useContext(ToastContext);
+
+export const ToastProvider = ({ children }) => {
+  const [toastMessage, setToastMessage] = useState(null);
+  const [toastVariant, setToastVariant] = useState('primary');
+  const [showToast, setShowToast] = useState(false);
+
+  const showToastMessage = (message, variant = 'primary') => {
+    setToastMessage(message);
+    setToastVariant(variant);
+    setShowToast(true);
+    setTimeout(() => setShowToast(false), 3000);
+  };
+
+  return (
+    <ToastContext.Provider
+      value={{ toastMessage, toastVariant, showToast, showToastMessage }}
+    >
+      {children}
+    </ToastContext.Provider>
+  );
+};
+
+export { ToastContext };

--- a/src/frontend/src/hooks/index.js
+++ b/src/frontend/src/hooks/index.js
@@ -1,0 +1,2 @@
+export { default as useAuth } from './useAuth';
+export { default as useToast } from './useToast';

--- a/src/frontend/src/hooks/useAuth.js
+++ b/src/frontend/src/hooks/useAuth.js
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { AuthContext } from '@/contexts/AuthContext';
 
-export function useAuth() {
+export default function useAuth() {
   return useContext(AuthContext);
 }

--- a/src/frontend/src/hooks/useToast.js
+++ b/src/frontend/src/hooks/useToast.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { ToastContext } from '@/contexts/ToastContext';
+
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/src/frontend/src/hooks/useToast.js
+++ b/src/frontend/src/hooks/useToast.js
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { ToastContext } from '@/contexts/ToastContext';
 
-export function useToast() {
+export default function useToast() {
   return useContext(ToastContext);
 }

--- a/src/frontend/src/main.jsx
+++ b/src/frontend/src/main.jsx
@@ -1,9 +1,9 @@
-import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { StrictMode } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './global.css';
-import App from './App.jsx';
-import { BrowserRouter } from 'react-router-dom';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/src/frontend/src/pages/HomePage.jsx
+++ b/src/frontend/src/pages/HomePage.jsx
@@ -1,54 +1,11 @@
-import { useState } from 'react';
-import { useAuth } from '@/hooks/useAuth';
 import Container from 'react-bootstrap/Container';
-import { getUserFromSession } from '@/utils/getUserFromSession';
+import ToastNotification from '../components/ToastNotification/ToastNotification';
 
 export default function HomePage() {
-  const user = getUserFromSession();
-  const { login, logout } = useAuth();
-  const [credentials, setCredentials] = useState({
-    username: '',
-    password: '',
-  });
-
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    await login(credentials);
-  };
-
   return (
     <Container>
       <h1>Homepage</h1>
-      <form onSubmit={handleSubmit}>
-        <input
-          type="text"
-          placeholder="Username"
-          value={credentials.username}
-          onChange={(e) =>
-            setCredentials({ ...credentials, username: e.target.value })
-          }
-        />
-        <input
-          type="password"
-          placeholder="Password"
-          value={credentials.password}
-          onChange={(e) =>
-            setCredentials({ ...credentials, password: e.target.value })
-          }
-        />
-        <button type="submit">Login</button>
-      </form>
-
-      {user ? (
-        <div>
-          <p>Logged in as {user.token}</p>
-          <button onClick={logout}>Logout</button>
-        </div>
-      ) : (
-        <div>
-          <p>Not logged in</p>
-        </div>
-      )}
+      <ToastNotification />
     </Container>
   );
 }

--- a/src/frontend/src/pages/HomePage.jsx
+++ b/src/frontend/src/pages/HomePage.jsx
@@ -1,5 +1,5 @@
 import Container from 'react-bootstrap/Container';
-import ToastNotification from '../components/ToastNotification/ToastNotification';
+import { ToastNotification } from '@/components';
 
 export default function HomePage() {
   return (

--- a/src/frontend/src/pages/ProfilePage.jsx
+++ b/src/frontend/src/pages/ProfilePage.jsx
@@ -1,16 +1,17 @@
-import { Container, Row, Col, Toast, Button } from 'react-bootstrap';
+import { Container, Row, Col, Button } from 'react-bootstrap';
 import { updateUserById, deleteUserById } from '@/services/userService';
 import { useAuth } from '@/hooks/useAuth';
 import UpdateProfileForm from '@/components/UpdateProfileForm/UpdateProfileForm';
 import DynamicBreadcrumb from '@/components/DynamicBreadcrumb/DynamicBreadcrumb';
 import { useState, useEffect } from 'react';
 import { getUserFromSession } from '@/utils/getUserFromSession';
+import { useToast } from '@/hooks/useToast';
+import ToastNotification from '../components/ToastNotification/ToastNotification';
 
 export default function ProfilePage() {
   const { logout } = useAuth();
-  const [showToast, setShowToast] = useState(false);
-  const [toastMessage, setToastMessage] = useState('');
-  const [toastVariant, setToastVariant] = useState('');
+  const { showToastMessage } = useToast();
+
   const [initialData, setInitialData] = useState(null);
 
   useEffect(() => {
@@ -21,36 +22,27 @@ export default function ProfilePage() {
   const handleUpdateProfile = async (updatedData) => {
     try {
       await updateUserById(updatedData);
-      setToastMessage(
+      showToastMessage(
         'Profile updated successfully! You will be logged out in 3 seconds.',
+        'success',
       );
-      setToastVariant('success');
-      setShowToast(true);
       setTimeout(() => {
-        setShowToast(false);
         logout();
       }, 3000);
     } catch {
-      setToastMessage('Error updating profile.');
-      setToastVariant('danger');
-      setShowToast(true);
+      showToastMessage('Error updating profile.', 'danger');
     }
   };
 
   const handleDeleteProfile = async () => {
     try {
       await deleteUserById();
-      setToastMessage('Profile deleted successfully!');
-      setToastVariant('success');
-      setShowToast(true);
+      showToastMessage('Profile deleted successfully!', 'success');
       setTimeout(() => {
-        setShowToast(false);
         logout();
       }, 3000);
     } catch {
-      setToastMessage('Error deleting profile.');
-      setToastVariant('danger');
-      setShowToast(true);
+      showToastMessage('Error deleting profile.', 'danger');
     }
   };
 
@@ -87,16 +79,7 @@ export default function ProfilePage() {
           </Button>
         </Col>
       </Row>
-      <Toast
-        onClose={() => setShowToast(false)}
-        show={showToast}
-        delay={3000}
-        autohide
-        bg={toastVariant}
-        className="position-fixed bottom-0 end-0 m-3"
-      >
-        <Toast.Body className="text-white">{toastMessage}</Toast.Body>
-      </Toast>
+      <ToastNotification />
     </Container>
   );
 }

--- a/src/frontend/src/pages/ProfilePage.jsx
+++ b/src/frontend/src/pages/ProfilePage.jsx
@@ -1,12 +1,13 @@
 import { Container, Row, Col, Button } from 'react-bootstrap';
 import { updateUserById, deleteUserById } from '@/services/userService';
-import { useAuth } from '@/hooks/useAuth';
-import UpdateProfileForm from '@/components/UpdateProfileForm/UpdateProfileForm';
-import DynamicBreadcrumb from '@/components/DynamicBreadcrumb/DynamicBreadcrumb';
+import { useAuth, useToast } from '@/hooks';
+import {
+  UpdateProfileForm,
+  ToastNotification,
+  DynamicBreadcrumb,
+} from '@/components';
 import { useState, useEffect } from 'react';
 import { getUserFromSession } from '@/utils/getUserFromSession';
-import { useToast } from '@/hooks/useToast';
-import ToastNotification from '../components/ToastNotification/ToastNotification';
 
 export default function ProfilePage() {
   const { logout } = useAuth();


### PR DESCRIPTION
This pull request introduces a Toast notification system to the application, refactoring existing code to use a new `ToastContext` for displaying messages. Additionally, it includes minor enhancements to form inputs for a better user experience. And clean up of the Home Page

### Toast Notification System:
* [`src/frontend/src/App.jsx`](diffhunk://#diff-02cfd7a23e4f0e1e03bb8ccc3d578d916c7331eb7b5847bf71d18fa02f4489a9R2): Wrapped the application with `ToastProvider` to enable toast notifications globally. [[1]](diffhunk://#diff-02cfd7a23e4f0e1e03bb8ccc3d578d916c7331eb7b5847bf71d18fa02f4489a9R2) [[2]](diffhunk://#diff-02cfd7a23e4f0e1e03bb8ccc3d578d916c7331eb7b5847bf71d18fa02f4489a9R16-R31)
* [`src/frontend/src/contexts/ToastContext.jsx`](diffhunk://#diff-f8389442a41b21a3dee1a5536e8ef0352cd0627ede95377e51f0ab904dbc5e1eR1-R28): Created `ToastContext` and `ToastProvider` to manage toast notifications.
* [`src/frontend/src/hooks/useToast.js`](diffhunk://#diff-86365020fe861a5f90c86cfc5e740ce1f2b1532a579033238223eee0d3ee6364R1-R6): Added a custom hook `useToast` for accessing the toast context.
* [`src/frontend/src/components/ToastNotification/ToastNotification.jsx`](diffhunk://#diff-6fb4f6b4930c4233e2fe0bcf022c7b6aa129c1b02517af185437c9accc33186bR1-R20): Created a `ToastNotification` component to display toast messages.
* Refactored components (`NavBar`, `PrivateRoute`, `ProfilePage`, `HomePage`) to use the new toast notification system. [[1]](diffhunk://#diff-fc8b5b77a7589f2a9c4fbba5ce959590059ce850594f91edc990ca1664689741L1-L22) [[2]](diffhunk://#diff-216e864124764266e2898697fe6af50166417dbc061050db721665ad5ed15d1aR1-R20) [[3]](diffhunk://#diff-18367cd419d289d3a5e167f9bdf12f990466ea21862183c75e5b1ef1f8a02d72L1-R14) [[4]](diffhunk://#diff-8a7a075cb269cb6118907b4e7e792f8b130da45ba3ff9627af33afcc674a1217L1-R8)

### Form Enhancements:
* Added `autoComplete` attributes to form inputs in `LoginForm` and `UpdateProfileForm` for better user experience. [[1]](diffhunk://#diff-88a6cb54c5cdc04f3efe6bbbbc80f472d1414aaa215ceb2a3dccec5980652cd9R29) [[2]](diffhunk://#diff-88a6cb54c5cdc04f3efe6bbbbc80f472d1414aaa215ceb2a3dccec5980652cd9R41) [[3]](diffhunk://#diff-7e5330e07ba26de0f91472dfef27f201a9889399022cb908f60da59db9572f47R31) [[4]](diffhunk://#diff-7e5330e07ba26de0f91472dfef27f201a9889399022cb908f60da59db9572f47R40) [[5]](diffhunk://#diff-7e5330e07ba26de0f91472dfef27f201a9889399022cb908f60da59db9572f47R49)