### PR TITLE
feat: set up media badge component and set this up on the page

### DIFF
--- a/src/frontend/src/components/MediaBadges/MediaBadges.css
+++ b/src/frontend/src/components/MediaBadges/MediaBadges.css
@@ -1,0 +1,3 @@
+.pointer {
+    cursor: pointer;
+  }

--- a/src/frontend/src/components/MediaBadges/MediaBadges.jsx
+++ b/src/frontend/src/components/MediaBadges/MediaBadges.jsx
@@ -1,0 +1,28 @@
+import { Badge, Row, Col } from 'react-bootstrap';
+import { useNavigate } from 'react-router';
+import './MediaBadges.css';
+
+export default function MediaBadges({ badges }) {
+  const navigate = useNavigate();
+
+  const handleBadgeClick = (badge) => {
+    if (badge) {
+      navigate(`/${badge.toLowerCase()}`);
+    }
+  };
+  return (
+    <Row>
+      {badges.map((badge, index) => (
+        <Col key={index} xs="auto" className="mb-2">
+          <Badge
+            bg="secondary"
+            onClick={() => handleBadgeClick(badge)}
+            className="pointer"
+          >
+            {badge}
+          </Badge>
+        </Col>
+      ))}
+    </Row>
+  );
+}

--- a/src/frontend/src/components/index.js
+++ b/src/frontend/src/components/index.js
@@ -10,3 +10,4 @@ export { default as ToastNotification } from './ToastNotification/ToastNotificat
 export { default as MediaCard } from './MediaCard/MediaCard';
 export { default as MediaGrid } from './MediaGrid/MediaGrid';
 export { default as MediaCarousel } from './MediaCarousel/MediaCarousel';
+export { default as MediaBadges } from './MediaBadges/MediaBadges';

--- a/src/frontend/src/pages/MediaDetailPage.jsx
+++ b/src/frontend/src/pages/MediaDetailPage.jsx
@@ -1,9 +1,40 @@
-import { Container } from 'react-bootstrap';
+import { useState } from 'react';
+import { Container, Tabs, Tab, Row, Col } from 'react-bootstrap';
+import { MediaBadges } from '@/components';
 
 export default function MediaDetailPage() {
+  const genres = ['Action', 'Comedy'];
+  const titles = [
+    'The Shawshank Redemption',
+    'La redención de Shawshank', // Spanish
+    'La rédemption de Shawshank', // French
+    'Die Verurteilten', // German
+    'Le ali della libertà', // Italian
+    'Shawshank Redemption', // Japanese
+  ];
+
+  const [activeKey, setActiveKey] = useState('genres');
+
   return (
     <Container>
       <h1>Media Detail</h1>
+      <Row>
+        <Col md={6}>
+          <Tabs
+            id="media-detail-tabs"
+            activeKey={activeKey}
+            onSelect={(k) => setActiveKey(k)}
+            className="mb-3"
+          >
+            <Tab eventKey="genres" title="Genres">
+              <MediaBadges title="Genres" badges={genres} />
+            </Tab>
+            <Tab eventKey="titles" title="Titles">
+              <MediaBadges title="Titles" badges={titles} />
+            </Tab>
+          </Tabs>
+        </Col>
+      </Row>
     </Container>
   );
 }


### PR DESCRIPTION
This pull request introduces a new `MediaBadges` component to the frontend. The changes include the addition of the component itself, its styling, and its integration into the `MediaDetailPage`.

### New Component Addition:

* [`src/frontend/src/components/MediaBadges/MediaBadges.jsx`](diffhunk://#diff-d9fca4520448b8a567a3b8bd0fb624541532d478a5ba05a531854a27bd388806R1-R28): Introduced a new `MediaBadges` component that displays badges and navigates to a corresponding page when a badge is clicked.
* [`src/frontend/src/components/MediaBadges/MediaBadges.css`](diffhunk://#diff-266b3ac051b2c3f3ee721de4ffffe47b2ae18b81b75f6ca187931798f43b4db9R1-R3): Added CSS styling for the `MediaBadges` component, including a pointer cursor for clickable badges.
* [`src/frontend/src/components/index.js`](diffhunk://#diff-812f2eaaa6f2e0da446fafe1709eb999dcbaf4fd5bb150c7f14933f2822a8a56R13): Exported the new `MediaBadges` component for use in other parts of the application.

### Integration:

* [`src/frontend/src/pages/MediaDetailPage.jsx`](diffhunk://#diff-9067da5199ca855ad6e34c7c96e7704c01a34040a5826da405606ca2edcb83ecL1-R37): Integrated the `MediaBadges` component into the `MediaDetailPage`, adding tabs for genres and titles, and using `useState` to manage active tabs.