### PR TITLE
fix: duplicate actor when multiple roles

### DIFF
--- a/src/frontend/src/components/PersonsCarousel/PersonsCarousel.jsx
+++ b/src/frontend/src/components/PersonsCarousel/PersonsCarousel.jsx
@@ -13,8 +13,8 @@ export default function PersonsCarousel({
       name={person.name}
       role={Array.isArray(person.role) ? person.role.join(', ') : person.role}
       additionalInfo={
-        person.character
-          ? `Character: ${person.character}`
+        person.character.length > 0
+          ? `Character: ${Array.isArray(person.character) ? person.character.join(', ') : person.character}`
           : person.additionalInfo
       }
       isLoading={loading}

--- a/src/frontend/src/components/PersonsCarousel/PersonsCarousel.jsx
+++ b/src/frontend/src/components/PersonsCarousel/PersonsCarousel.jsx
@@ -12,7 +12,11 @@ export default function PersonsCarousel({
       pictureUri={person.pictureUri}
       name={person.name}
       role={Array.isArray(person.role) ? person.role.join(', ') : person.role}
-      additionalInfo={person.additionalInfo}
+      additionalInfo={
+        person.character
+          ? `Character: ${person.character}`
+          : person.additionalInfo
+      }
       isLoading={loading}
     />
   );

--- a/src/frontend/src/components/PersonsCarousel/PersonsCarousel.jsx
+++ b/src/frontend/src/components/PersonsCarousel/PersonsCarousel.jsx
@@ -11,7 +11,7 @@ export default function PersonsCarousel({
       id={person.id}
       pictureUri={person.pictureUri}
       name={person.name}
-      role={person.role}
+      role={Array.isArray(person.role) ? person.role.join(', ') : person.role}
       additionalInfo={person.additionalInfo}
       isLoading={loading}
     />

--- a/src/frontend/src/pages/MediaDetailPage.jsx
+++ b/src/frontend/src/pages/MediaDetailPage.jsx
@@ -40,16 +40,19 @@ const mergeRoles = (people) => {
   const merged = {};
 
   people.forEach((person) => {
+    const role = person.role ? person.role : undefined;
     if (merged[person.personId]) {
-      merged[person.personId].role = Array.from(
-        new Set([...merged[person.personId].role, person.role]),
-      );
+      if (role) {
+        merged[person.personId].role = Array.from(
+          new Set([...merged[person.personId].role, role]),
+        );
+      }
     } else {
       merged[person.personId] = {
         ...person,
         id: person.personId,
         name: person.personName,
-        role: [person.role],
+        role: role ? [role] : [],
       };
     }
   });

--- a/src/frontend/src/pages/MediaDetailPage.jsx
+++ b/src/frontend/src/pages/MediaDetailPage.jsx
@@ -36,6 +36,27 @@ const extractWriters = (crew) => {
 const extractProducers = (crew) =>
   extractMembersByJobCategory(crew, 'producer');
 
+const mergeRoles = (people) => {
+  const merged = {};
+
+  people.forEach((person) => {
+    if (merged[person.personId]) {
+      merged[person.personId].role = Array.from(
+        new Set([...merged[person.personId].role, person.role]),
+      );
+    } else {
+      merged[person.personId] = {
+        ...person,
+        id: person.personId,
+        name: person.personName,
+        role: [person.role],
+      };
+    }
+  });
+
+  return Object.values(merged);
+};
+
 export default function MediaDetailPage() {
   const { id: mediaId } = useParams();
   const navigate = useNavigate();
@@ -99,6 +120,8 @@ export default function MediaDetailPage() {
   const writers = extractWriters(crew);
   const producers = extractProducers(crew);
 
+  const mergedCrew = mergeRoles(crew);
+  const mergedCast = mergeRoles(cast);
   return (
     <Container>
       <MediaInformation
@@ -139,30 +162,34 @@ export default function MediaDetailPage() {
       <Row className="mt-5">
         <Col>
           <Tabs defaultActiveKey="crew" id="crew-cast-tabs" className="mb-3">
-            <Tab eventKey="crew" title="Crew">
-              <PersonsCarousel
-                persons={crew.map((person) => ({
-                  ...person,
-                  id: person.personId,
-                  name: person.personName,
-                }))}
-                loading={loadingCrew}
-                onLoadMore={handleLoadMoreCrew}
-                hasNextPage={hasMoreCrew}
-              />
-            </Tab>
-            <Tab eventKey="cast" title="Cast">
-              <PersonsCarousel
-                persons={cast.map((person) => ({
-                  ...person,
-                  id: person.personId,
-                  name: person.personName,
-                }))}
-                loading={loadingCast}
-                onLoadMore={handleLoadMoreCast}
-                hasNextPage={hasMoreCast}
-              />
-            </Tab>
+            {mergedCrew.length > 0 && (
+              <Tab eventKey="crew" title="Crew">
+                <PersonsCarousel
+                  persons={mergedCrew.map((person) => ({
+                    ...person,
+                    id: person.personId,
+                    name: person.personName,
+                  }))}
+                  loading={loadingCrew}
+                  onLoadMore={handleLoadMoreCrew}
+                  hasNextPage={hasMoreCrew}
+                />
+              </Tab>
+            )}
+            {mergedCast.length > 0 && (
+              <Tab eventKey="cast" title="Cast">
+                <PersonsCarousel
+                  persons={mergedCast.map((person) => ({
+                    ...person,
+                    id: person.personId,
+                    name: person.personName,
+                  }))}
+                  loading={loadingCast}
+                  onLoadMore={handleLoadMoreCast}
+                  hasNextPage={hasMoreCast}
+                />
+              </Tab>
+            )}
           </Tabs>
         </Col>
       </Row>

--- a/src/frontend/src/pages/MediaDetailPage.jsx
+++ b/src/frontend/src/pages/MediaDetailPage.jsx
@@ -41,10 +41,16 @@ const mergeRoles = (people) => {
 
   people.forEach((person) => {
     const role = person.role ? person.role : undefined;
+    const character = person.character ? person.character : undefined;
     if (merged[person.personId]) {
       if (role) {
         merged[person.personId].role = Array.from(
           new Set([...merged[person.personId].role, role]),
+        );
+      }
+      if (character) {
+        merged[person.personId].character = Array.from(
+          new Set([...merged[person.personId].character, character]),
         );
       }
     } else {
@@ -53,6 +59,7 @@ const mergeRoles = (people) => {
         id: person.personId,
         name: person.personName,
         role: role ? [role] : [],
+        character: character ? [character] : [],
       };
     }
   });


### PR DESCRIPTION
This pull request includes changes to the `MediaDetailPage` and `PersonsCarousel` components to improve crew and cast members' handling and display of roles. The most important changes include introducing a new function to merge roles, updating how roles are displayed, and conditional rendering of tabs.

Enhancements to role handling and display:

* [`src/frontend/src/components/PersonsCarousel/PersonsCarousel.jsx`](diffhunk://#diff-f124bc23b307bb6de3f29438dcd1a02ed871c1c0743fde0a59d89fa672aeb3bbL14-R14): Updated the `role` prop to handle arrays by joining them into a string.
* [`src/frontend/src/pages/MediaDetailPage.jsx`](diffhunk://#diff-9067da5199ca855ad6e34c7c96e7704c01a34040a5826da405606ca2edcb83ecR39-R62): Added a new `mergeRoles` function to merge roles for crew and cast members into arrays, ensuring unique roles are combined.
* [`src/frontend/src/pages/MediaDetailPage.jsx`](diffhunk://#diff-9067da5199ca855ad6e34c7c96e7704c01a34040a5826da405606ca2edcb83ecR126-R127): Updated the `MediaDetailPage` component to use `mergedCrew` and `mergedCast` for the `PersonsCarousel` components, ensuring roles are properly merged and displayed. [[1]](diffhunk://#diff-9067da5199ca855ad6e34c7c96e7704c01a34040a5826da405606ca2edcb83ecR126-R127) [[2]](diffhunk://#diff-9067da5199ca855ad6e34c7c96e7704c01a34040a5826da405606ca2edcb83ecR168-R171) [[3]](diffhunk://#diff-9067da5199ca855ad6e34c7c96e7704c01a34040a5826da405606ca2edcb83ecR181-R185) [[4]](diffhunk://#diff-9067da5199ca855ad6e34c7c96e7704c01a34040a5826da405606ca2edcb83ecR195)