### PR TITLE
feat: change button position on grid

### DIFF
--- a/src/frontend/src/components/MediaGrid/MediaGrid.jsx
+++ b/src/frontend/src/components/MediaGrid/MediaGrid.jsx
@@ -16,7 +16,7 @@ export default function MediaGrid({ media, onShowMore }) {
   };
 
   return (
-    <Container fluid className="container-layout ">
+    <Container fluid className="container-layout">
       <Row>
         {firstRowMedia.map((media, index) => (
           <Col
@@ -35,43 +35,47 @@ export default function MediaGrid({ media, onShowMore }) {
               title={media.title}
               releaseYear={new Date(media.releaseDate).getFullYear().toString()}
             />
-            {index === firstRowMedia.length - 1 &&
-              remainingMedia.length > 0 && (
-                <Button
-                  variant="link"
-                  onClick={handleShowMore}
-                  className="see-more-button"
-                >
-                  {showMore ? 'See Less' : 'See More'}
-                </Button>
-              )}
+            {index === 0 && remainingMedia.length > 0 && !showMore && (
+              <Button variant="link" onClick={handleShowMore} className="p-0">
+                See More
+              </Button>
+            )}
           </Col>
         ))}
       </Row>
       {showMore && (
-        <Row>
-          {remainingMedia.map((media, index) => (
-            <Col
-              key={index}
-              xs={12}
-              sm={6}
-              md={4}
-              lg={3}
-              xl={2}
-              className="position-relative"
-            >
-              <MediaCard
-                id={media.id}
-                imageUri={media.posterUri}
-                type={media.type}
-                title={media.title}
-                releaseYear={new Date(media.releaseDate)
-                  .getFullYear()
-                  .toString()}
-              />
+        <>
+          <Row>
+            {remainingMedia.map((media, index) => (
+              <Col
+                key={index}
+                xs={12}
+                sm={6}
+                md={4}
+                lg={3}
+                xl={2}
+                className="position-relative"
+              >
+                <MediaCard
+                  id={media.id}
+                  imageUri={media.posterUri}
+                  type={media.type}
+                  title={media.title}
+                  releaseYear={new Date(media.releaseDate)
+                    .getFullYear()
+                    .toString()}
+                />
+              </Col>
+            ))}
+          </Row>
+          <Row>
+            <Col className="text-left">
+              <Button variant="link" onClick={handleShowMore} className="p-0">
+                See Less
+              </Button>
             </Col>
-          ))}
-        </Row>
+          </Row>
+        </>
       )}
     </Container>
   );

--- a/src/frontend/src/components/PersonsGrid/PersonsGrid.jsx
+++ b/src/frontend/src/components/PersonsGrid/PersonsGrid.jsx
@@ -4,12 +4,17 @@ import { PersonCard } from '@/components';
 import { useItemsPerRow } from '@/hooks';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
-export default function PersonsGrid({ persons }) {
+export default function PersonsGrid({ persons, onShowMore }) {
   const [showMore, setShowMore] = useState(false);
   const itemsPerRow = useItemsPerRow();
 
   const firstRowPersons = persons.slice(0, itemsPerRow);
   const remainingPersons = persons.slice(itemsPerRow);
+
+  const handleShowMore = () => {
+    setShowMore(!showMore);
+    onShowMore?.(showMore);
+  };
 
   return (
     <Container fluid className="container-layout">
@@ -31,41 +36,45 @@ export default function PersonsGrid({ persons }) {
               role={person.role}
               additionalInfo={person.additionalInfo}
             />
-            {index === firstRowPersons.length - 1 &&
-              remainingPersons.length > 0 && (
-                <Button
-                  variant="link"
-                  onClick={() => setShowMore(!showMore)}
-                  className="see-more-button"
-                >
-                  {showMore ? 'See Less' : 'See More'}
-                </Button>
-              )}
+            {index === 0 && remainingPersons.length > 0 && !showMore && (
+              <Button variant="link" onClick={handleShowMore} className="p-0">
+                {showMore ? 'See Less' : 'See More'}
+              </Button>
+            )}
           </Col>
         ))}
       </Row>
       {showMore && (
-        <Row>
-          {remainingPersons.map((person, index) => (
-            <Col
-              key={index}
-              xs={12}
-              sm={6}
-              md={4}
-              lg={3}
-              xl={2}
-              className="position-relative"
-            >
-              <PersonCard
-                id={person.id}
-                pictureUri={person.pictureUri}
-                name={person.name}
-                role={person.role}
-                additionalInfo={person.additionalInfo}
-              />
+        <>
+          <Row>
+            {remainingPersons.map((person, index) => (
+              <Col
+                key={index}
+                xs={12}
+                sm={6}
+                md={4}
+                lg={3}
+                xl={2}
+                className="position-relative"
+              >
+                <PersonCard
+                  id={person.id}
+                  pictureUri={person.pictureUri}
+                  name={person.name}
+                  role={person.role}
+                  additionalInfo={person.additionalInfo}
+                />
+              </Col>
+            ))}
+          </Row>
+          <Row>
+            <Col className="text-left">
+              <Button variant="link" onClick={handleShowMore} className="p-0">
+                See Less
+              </Button>
             </Col>
-          ))}
-        </Row>
+          </Row>
+        </>
       )}
     </Container>
   );

--- a/src/frontend/src/global.css
+++ b/src/frontend/src/global.css
@@ -20,13 +20,6 @@
   background-color: rgba(0, 0, 0, 1);
 }
 
-.see-more-button.btn {
-  position: absolute;
-  top: -2rem;
-  right: 0;
-  color: black;
-}
-
 .responsive-img {
   height: 68px;
 }


### PR DESCRIPTION
This pull request includes several changes to the `MediaGrid` and `PersonsGrid` components to improve the user interface and functionality. The primary changes involve the handling of the "See More" button, adding a "See Less" button, and removing unnecessary CSS styles.

Changes to `MediaGrid` component:

* Modified the placement and visibility logic of the "See More" button to appear at the beginning of the first row and added a "See Less" button when additional media items are shown (`src/frontend/src/components/MediaGrid/MediaGrid.jsx`). [[1]](diffhunk://#diff-ea9f44ae7bfdec5db6a214a7518a834a5cab7097071ea873d3b3e5dc0100c079L38-R47) [[2]](diffhunk://#diff-ea9f44ae7bfdec5db6a214a7518a834a5cab7097071ea873d3b3e5dc0100c079R71-R78)

Changes to `PersonsGrid` component:

* Added `onShowMore` prop and `handleShowMore` function to toggle the visibility of additional person items and added a "See Less" button when additional person items are shown (`src/frontend/src/components/PersonsGrid/PersonsGrid.jsx`). [[1]](diffhunk://#diff-358e0ee73b6b9099027e612bf257e1e04c483af465810499d3dd2dadce5d808fL7-R18) [[2]](diffhunk://#diff-358e0ee73b6b9099027e612bf257e1e04c483af465810499d3dd2dadce5d808fL34-R48) [[3]](diffhunk://#diff-358e0ee73b6b9099027e612bf257e1e04c483af465810499d3dd2dadce5d808fR70-R77)

CSS cleanup:

* Removed the `.see-more-button` CSS class as it is no longer needed (`src/frontend/src/global.css`).