### PR TITLE
feat: insert users personal rating on a media if rated

### DIFF
--- a/src/frontend/src/components/MediaInformation/MediaInformation.jsx
+++ b/src/frontend/src/components/MediaInformation/MediaInformation.jsx
@@ -8,6 +8,7 @@ import {
   Placeholder,
 } from 'react-bootstrap';
 import { formatDate } from '@/utils';
+import { useUserData } from '@/contexts';
 import {
   PlaceholderText,
   DefaultImage,
@@ -27,6 +28,8 @@ export default function MediaInformation({
   writer,
   producer,
   scores,
+  releases,
+  mediaId,
 }) {
   const [showMore, setShowMore] = useState(false);
 
@@ -36,6 +39,33 @@ export default function MediaInformation({
     plot?.length > 200 ? plot.substring(0, 200) + '...' : plot;
 
   const isLoading = !title;
+  const { completed } = useUserData();
+
+  const getUserScore = () => {
+    const completedMedia = completed.find(
+      (item) => item.mediaId === parseInt(mediaId),
+    );
+    console.log('completedMedia:', completedMedia);
+    return completedMedia?.score?.value || 'No Score Available';
+  };
+
+  const userScore = getUserScore();
+
+  const getCombinedRatings = () => {
+    const releaseRatings = releases
+      ? releases.map((release) => ({
+          source: 'Release Rating',
+          value: release.rated,
+        }))
+      : [];
+    const userRating =
+      userScore !== 'No Score Available'
+        ? [{ source: 'User Score', value: userScore }]
+        : [];
+    return [...(scores || []), ...releaseRatings, ...userRating];
+  };
+
+  const combinedRatings = getCombinedRatings();
 
   return (
     <Container className="container-layout">
@@ -167,7 +197,7 @@ export default function MediaInformation({
           </Row>
           <Row>
             <Col>
-              <Rating ratings={scores} />
+              <Rating ratings={combinedRatings} />
             </Col>
           </Row>
         </Col>

--- a/src/frontend/src/components/Rating/Rating.jsx
+++ b/src/frontend/src/components/Rating/Rating.jsx
@@ -19,17 +19,19 @@ export default function Rating({ ratings }) {
       return 'Metacritic';
     } else if (source === 'rottentomatoes') {
       return 'Rotten Tomatoes';
+    } else if (source === 'User Score') {
+      return 'Your personal';
     }
     return source;
   };
 
   return (
     <>
-      <div className="d-flex w-100 mt-5">
+      <div className="d-flex flex-column flex-md-row w-100 mt-5">
         {ratings.map((rating, index) => (
           <div
             key={index}
-            className="d-flex flex-column align-items-center w-100"
+            className="d-flex flex-column align-items-center w-100 mb-3 mb-md-0"
           >
             <p className="mb-3">
               <strong>{formatSourceName(rating.source)} rating</strong>
@@ -64,12 +66,30 @@ export default function Rating({ ratings }) {
               <div className="d-flex flex-column">
                 <p className="mb-0 fs-5">
                   <span className="fw-bold">
-                    {' '}
                     {typeof rating.value === 'number'
                       ? rating.value.toFixed(1)
                       : rating.value}
                   </span>
                 </p>
+              </div>
+            ) : rating.source === 'User Score' ? (
+              <div className="d-flex align-items-center gap-2">
+                <ReactStarsRating
+                  value={1}
+                  count={1}
+                  size={30}
+                  isHalf={false}
+                  primaryColor="orange"
+                  secondaryColor="grey"
+                />
+                <div className="d-flex flex-column">
+                  <p className="mb-0 fs-5">
+                    <span className="fw-bold">{rating.value}</span>/10
+                  </p>
+                  {rating.voteCount && (
+                    <p className="mb-0">{formatVoteCount(rating.voteCount)}</p>
+                  )}
+                </div>
               </div>
             ) : (
               <div className="d-flex flex-column">

--- a/src/frontend/src/pages/MediaDetailPage.jsx
+++ b/src/frontend/src/pages/MediaDetailPage.jsx
@@ -134,6 +134,7 @@ export default function MediaDetailPage() {
     <Container>
       <MediaInformation
         {...mediaData}
+        mediaId={mediaId}
         director={directors}
         writer={writers}
         producer={producers}


### PR DESCRIPTION
This pull request includes several changes to the `MediaInformation` and `Rating` components to incorporate user scores and improve the display of ratings. The most important changes are outlined below:

Enhancements to `MediaInformation` component:

* [`src/frontend/src/components/MediaInformation/MediaInformation.jsx`](diffhunk://#diff-1c6dba6e61786d471185066fa8b0804d3e551ce373e9ebaddaa916c075dbae12R11): Imported `useUserData` from `@/contexts` to access user data.
* [`src/frontend/src/components/MediaInformation/MediaInformation.jsx`](diffhunk://#diff-1c6dba6e61786d471185066fa8b0804d3e551ce373e9ebaddaa916c075dbae12R31-R32): Added `releases` and `mediaId` to the component's props.
* [`src/frontend/src/components/MediaInformation/MediaInformation.jsx`](diffhunk://#diff-1c6dba6e61786d471185066fa8b0804d3e551ce373e9ebaddaa916c075dbae12R42-R68): Added functions to retrieve user scores and combine them with existing ratings.
* [`src/frontend/src/components/MediaInformation/MediaInformation.jsx`](diffhunk://#diff-1c6dba6e61786d471185066fa8b0804d3e551ce373e9ebaddaa916c075dbae12L170-R200): Updated the `Rating` component to use the combined ratings.

Improvements to `Rating` component:

* [`src/frontend/src/components/Rating/Rating.jsx`](diffhunk://#diff-952c6b33e1548b29ee68b2999a7039d6c02e057835bf1fdf45df32d408a43e9aR22-R34): Enhanced `formatSourceName` to handle user scores and updated the layout for displaying ratings. [[1]](diffhunk://#diff-952c6b33e1548b29ee68b2999a7039d6c02e057835bf1fdf45df32d408a43e9aR22-R34) [[2]](diffhunk://#diff-952c6b33e1548b29ee68b2999a7039d6c02e057835bf1fdf45df32d408a43e9aL67-R93)

Additional changes:

* [`src/frontend/src/pages/MediaDetailPage.jsx`](diffhunk://#diff-9067da5199ca855ad6e34c7c96e7704c01a34040a5826da405606ca2edcb83ecR137): Passed `mediaId` to the `MediaInformation` component.