### PR TITLE
fix: set up fetching all titles and display 

### DIFF
--- a/src/frontend/src/components/MediaBadges/MediaBadges.jsx
+++ b/src/frontend/src/components/MediaBadges/MediaBadges.jsx
@@ -1,26 +1,12 @@
-import { useNavigate } from 'react-router';
 import { Badge, Row, Col } from 'react-bootstrap';
 import './MediaBadges.css';
 
 export default function MediaBadges({ badges }) {
-  const navigate = useNavigate();
-
-  const handleBadgeClick = (badge) => {
-    if (badge) {
-      navigate(`/${badge.toLowerCase()}`);
-    }
-  };
   return (
     <Row>
       {badges.map((badge, index) => (
         <Col key={index} xs="auto" className="mb-2">
-          <Badge
-            bg="secondary"
-            onClick={() => handleBadgeClick(badge)}
-            className="pointer"
-          >
-            {badge}
-          </Badge>
+          <Badge bg="secondary">{badge}</Badge>
         </Col>
       ))}
     </Row>

--- a/src/frontend/src/pages/MediaDetailPage.jsx
+++ b/src/frontend/src/pages/MediaDetailPage.jsx
@@ -19,7 +19,7 @@ import {
   MediaTypeBadge,
 } from '@/components';
 import { useToast } from '@/contexts';
-import { extractMembersByJobCategory } from '@/utils';
+import { extractMembersByJobCategory, fetchAllPages } from '@/utils';
 import { usePaginatedData } from '@/hooks';
 
 const extractDirectors = (crew) =>
@@ -100,8 +100,11 @@ export default function MediaDetailPage() {
       setLoading(true);
       const mediaData = await fetchMediaById(mediaId);
       setMediaData(mediaData);
-      const titlesData = await fetchTitles(mediaId);
-      setTitles(titlesData);
+      const allTitles = await fetchAllPages(
+        (page, count) => fetchTitles(mediaId, page, count),
+        10,
+      );
+      setTitles(allTitles);
       const releasesData = await fetchReleases(mediaId);
       setReleases(releasesData.items);
     } catch (error) {

--- a/src/frontend/src/services/mediaService.js
+++ b/src/frontend/src/services/mediaService.js
@@ -16,11 +16,16 @@ export const fetchMediaById = async (id) => {
   }
 };
 
-export const fetchTitles = async (id) => {
+export const fetchTitles = async (id, page, count) => {
   const api = new ApiClient();
+  const queryParams = [
+    { key: 'page', value: page },
+    { key: 'count', value: count },
+  ];
+
   const path = `/api/media/${id}/titles`;
   try {
-    const response = await api.Get(path);
+    const response = await api.Get(path, queryParams);
     if (!response.ok) {
       throw new Error(`Failed to fetch titles for media ID ${id}.`);
     }


### PR DESCRIPTION
This pull request includes several changes to the frontend components and services to improve the handling and display of media badges and titles. The most important changes include removing unused navigation logic from the `MediaBadges` component, updating the `MediaDetailPage` to fetch all pages of titles, and modifying the `fetchTitles` service to support pagination.

### Frontend Component Updates:

* [`src/frontend/src/components/MediaBadges/MediaBadges.jsx`](diffhunk://#diff-d9fca4520448b8a567a3b8bd0fb624541532d478a5ba05a531854a27bd388806L1-R9): Removed unused `useNavigate` import and the `handleBadgeClick` function, simplifying the `Badge` component to no longer handle clicks.

* [`src/frontend/src/pages/MediaDetailPage.jsx`](diffhunk://#diff-9067da5199ca855ad6e34c7c96e7704c01a34040a5826da405606ca2edcb83ecL22-R22): Added `fetchAllPages` utility to import and updated the `fetchTitles` call to use pagination, ensuring all titles are fetched and set. [[1]](diffhunk://#diff-9067da5199ca855ad6e34c7c96e7704c01a34040a5826da405606ca2edcb83ecL22-R22) [[2]](diffhunk://#diff-9067da5199ca855ad6e34c7c96e7704c01a34040a5826da405606ca2edcb83ecL103-R107)

### Service Updates:

* [`src/frontend/src/services/mediaService.js`](diffhunk://#diff-337b1594ea5513a006c2589f5ce02e2b7ba67fdb8be37b75ced9be883c1b4dcfL19-R28): Modified the `fetchTitles` function to accept `page` and `count` parameters and updated the API call to include these query parameters, enabling pagination support.